### PR TITLE
Fixed build warnings and made min/max computation reflect all channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Call `melatonin::printSparkline(myAudioBlock);` and under the hood, DBG will be 
 If you are lucky, you'll see a healthy looking wave (like this cutie little square wave) spat out into your console:
 
 ```
-Block is 1 channel, 441 samples, min -0.999994, max 0.999994, 100% filled
+AudioBlock<float> (1 channel, 441 samples, min -0.999994, max 0.999994, 100% filled) with content
 [0⎺‾⎺x⎽_⎽]
 ```
 
 Or a sine: 
 
 ```
-Block is 1 channel, 441 samples, min -0.999994, max 0.999994, 100% filled
+AudioBlock<const double> (1 channel, 441 samples, min -0.999994, max 0.999994, 100% filled) with content
 [0—⎻⎺‾⎺⎻—x—⎼⎽_⎽⎼—]
 ```
 

--- a/melatonin_audio_sparklines.h
+++ b/melatonin_audio_sparklines.h
@@ -157,6 +157,7 @@ namespace melatonin
     static inline void printSparkline (const AudioBlock<SampleType>& block, bool collapse = true)
     {
         DBG (sparkline (block, collapse));
+        juce::ignoreUnused (block, collapse);
     }
 
     // asArray adds a comma to help you copy and paste the numbers into another context, like python

--- a/melatonin_audio_sparklines.h
+++ b/melatonin_audio_sparklines.h
@@ -22,6 +22,13 @@ namespace melatonin
     template <typename SampleType>
     using AudioBlock = juce::dsp::AudioBlock<SampleType>;
 
+    template <typename T> struct TypeNameString               { static std::string get() { return typeid (T).name(); } };
+    template <typename T> struct TypeNameString<const T>      { static std::string get() { return "const " + TypeNameString<std::remove_const_t<T>>::get(); }};
+    template <>           struct TypeNameString<float>        { static std::string get() { return "float"; } };
+    template <>           struct TypeNameString<double>       { static std::string get() { return "double"; } };
+
+    template <typename T> std::string typeNameString() { return TypeNameString<T>::get(); }
+
     // This only reports when more than one 0 is in a row
     // In other words, it won't report a single zero starting a sine wave, for example
     template <typename SampleType>
@@ -68,7 +75,12 @@ namespace melatonin
 
         std::ostringstream summary;
 
-        summary << "Block is " << block.getNumChannels() << " channels, " << block.getNumSamples() << " samples, min " << overallMin << ", max " << overallMax << ", " << percentFilled (block) << "% filled\n";
+        summary << "AudioBlock<" << typeNameString<SampleType>() <<
+                   "> (" << block.getNumChannels() << (block.getNumChannels() == 1 ? " channel, " : " channels, ") <<
+                   block.getNumSamples() << " samples, min " <<
+                   overallMin << ", max " <<
+                   overallMax << ", " << percentFilled (block) << "% filled) with content\n";
+
         return summary.str();
     }
 

--- a/melatonin_audio_sparklines.h
+++ b/melatonin_audio_sparklines.h
@@ -80,8 +80,8 @@ namespace melatonin
                 juce::String waveform = juce::CharPointer_UTF8 ("_\xe2\x8e\xbd\xe2\x8e\xbc\xe2\x80\x94\xe2\x8e\xbb\xe2\x8e\xba\xe2\x80\xbe"); // L"_⎽⎼—⎻⎺‾";
             #endif
 
-            float absMax = abs (juce::FloatVectorOperations::findMaximum (block.getChannelPointer (c), block.getNumSamples()));
-            float absMin = abs (juce::FloatVectorOperations::findMinimum (block.getChannelPointer (c), block.getNumSamples()));
+            float absMax = abs (juce::FloatVectorOperations::findMaximum (block.getChannelPointer (c), (int) block.getNumSamples()));
+            float absMin = abs (juce::FloatVectorOperations::findMinimum (block.getChannelPointer (c), (int) block.getNumSamples()));
             float channelMax = juce::jmax (absMin, absMax);
 
             sparkline += "[";

--- a/melatonin_audio_sparklines.h
+++ b/melatonin_audio_sparklines.h
@@ -51,8 +51,11 @@ namespace melatonin
     template <typename SampleType>
     static inline juce::String summaryOf (const AudioBlock<SampleType>& block)
     {
-        std::vector<SampleType> min (block.getNumChannels());
-        std::vector<SampleType> max (block.getNumChannels());
+        // We need to handle the case where e.g. an AudioBlock<const float> is passed to this function
+        using NonConstSampleType = std::remove_const_t<SampleType>;
+
+        std::vector<NonConstSampleType> min (block.getNumChannels());
+        std::vector<NonConstSampleType> max (block.getNumChannels());
 
         for (size_t ch = 0; ch < block.getNumChannels(); ++ch)
         {

--- a/melatonin_audio_sparklines.h
+++ b/melatonin_audio_sparklines.h
@@ -51,11 +51,21 @@ namespace melatonin
     template <typename SampleType>
     static inline juce::String summaryOf (const AudioBlock<SampleType>& block)
     {
-        float min = juce::FloatVectorOperations::findMinimum (block.getChannelPointer (0), (int) block.getNumSamples());
-        float max = juce::FloatVectorOperations::findMaximum (block.getChannelPointer (0), (int) block.getNumSamples());
+        std::vector<SampleType> min (block.getNumChannels());
+        std::vector<SampleType> max (block.getNumChannels());
+
+        for (size_t ch = 0; ch < block.getNumChannels(); ++ch)
+        {
+            min[ch] = juce::FloatVectorOperations::findMinimum (block.getChannelPointer (ch), (int) block.getNumSamples());
+            max[ch] = juce::FloatVectorOperations::findMaximum (block.getChannelPointer (ch), (int) block.getNumSamples());
+        }
+
+        const auto overallMin = juce::FloatVectorOperations::findMinimum (min.data(), (int) block.getNumChannels());
+        const auto overallMax = juce::FloatVectorOperations::findMaximum (max.data(), (int) block.getNumChannels());
+
         std::ostringstream summary;
 
-        summary << "Block is " << block.getNumChannels() << " channels, " << block.getNumSamples() << " samples, min " << min << ", max " << max << ", " << percentFilled (block) << "% filled\n";
+        summary << "Block is " << block.getNumChannels() << " channels, " << block.getNumSamples() << " samples, min " << overallMin << ", max " << overallMax << ", " << percentFilled (block) << "% filled\n";
         return summary.str();
     }
 


### PR DESCRIPTION
`summaryOf` only computed minimum and maximum values for the first channel, which might not always be what you want. With the proposed changes the overall min and max values for all channels are computed.