### PR TITLE
Fixes for supporting double sample data

### DIFF
--- a/melatonin_audio_sparklines.h
+++ b/melatonin_audio_sparklines.h
@@ -237,7 +237,8 @@ namespace melatonin
         DBG (output);
     }
 
-    [[maybe_unused]] static std::string blockToString (const AudioBlock<float>& block, int decimalPlaces = 6)
+    template <typename SampleType>
+    [[maybe_unused]] static std::string blockToString (const AudioBlock<SampleType>& block, int decimalPlaces = 6)
     {
         auto output = std::string();
 
@@ -254,7 +255,8 @@ namespace melatonin
         return oss.str();
     }
 
-    [[maybe_unused]] static std::string vectorToString (const std::vector<float>& v, int decimalPlaces = 6)
+    template <typename SampleType>
+    [[maybe_unused]] static std::string vectorToString (const std::vector<SampleType>& v, int decimalPlaces = 6)
     {
         if (v.empty())
             return "";

--- a/melatonin_audio_sparklines.h
+++ b/melatonin_audio_sparklines.h
@@ -186,7 +186,7 @@ namespace melatonin
         juce::String output;
         for (int i = 0; i < (int) block.getNumSamples(); i++)
         {
-            float value = block.getSample (0, i);
+            SampleType value = block.getSample (0, i);
             output += juce::String (value, precision); // 3 significant digits by default
             if (asArray)
                 output += ",";
@@ -213,7 +213,7 @@ namespace melatonin
         juce::String output;
         for (size_t i = 0; i < data.size(); i++)
         {
-            auto value = static_cast<float> (data[i]);
+            auto value = static_cast<SampleType> (data[i]);
             output += juce::String (value, precision); // 3 significant digits by default
             if (asArray)
                 output += ",";
@@ -228,7 +228,7 @@ namespace melatonin
         juce::String output;
         for (int i = 0; i < (int) numSamples; i++)
         {
-            auto value = static_cast<float> (data[i]);
+            auto value = static_cast<SampleType> (data[i]);
             output += juce::String (value, precision); // 3 significant digits by default
             if (asArray)
                 output += ",";


### PR DESCRIPTION
Hi @sudara, I ran into issues with double audio buffers again today with melatonin_audio_sparklines and melatonin_test_helpers, so I figured I'd put together a few fixes rather than just be a complainer. Feel free to tweak as you see fit. Thank you!

Note that I've sent pull requests for both projects and both are needed for this all to work right.

https://github.com/sudara/melatonin_test_helpers/issues/6